### PR TITLE
test only for integer when string is numeric

### DIFF
--- a/src/Validator/Integer.php
+++ b/src/Validator/Integer.php
@@ -17,7 +17,8 @@ class Integer extends Validator
     public function validate($value, array $context = []): bool
     {
         if (is_int($value) ||
-            (is_string($value) || is_double($value)) && (double)$value === round((double)$value)
+            (is_string($value) && is_numeric($value) || is_double($value)) &&
+            (double)$value === round((double)$value)
         ) {
             return true;
         }

--- a/tests/Validator/IntegerTest.php
+++ b/tests/Validator/IntegerTest.php
@@ -26,6 +26,14 @@ class IntegerTest extends TestCase
         self::assertTrue($validator->validate($string));
     }
 
+    /** @test */
+    public function doesNotAllowNonNumericStrings()
+    {
+        $validator = new Integer();
+
+        self::assertFalse($validator->validate('foo'));
+    }
+
     public function provideValidStrings()
     {
         return [


### PR DESCRIPTION
`(double)'foo'` always returns 0 what is an integer too.

/solves #17