### PR TITLE
execute `Field::filter()` in `Field::validate()`

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -270,7 +270,7 @@ class Field
             } catch (InvalidValue $e) {
                 $this->filterFailed = true;
                 $this->errors = $e->errors;
-                return $value;
+                break;
             }
         }
 
@@ -291,12 +291,14 @@ class Field
      */
     public function validate($value, array $context = [])
     {
+        $filtered = $this->filter($value, $context);
+
         if ($this->filterFailed) {
             return false;
         }
 
         try {
-            $hash = md5(serialize([$value, $context]));
+            $hash = md5(serialize([$filtered, $context]));
             if (isset($this->validationCache[$hash])) {
                 return $this->validationCache[$hash];
             }
@@ -308,7 +310,7 @@ class Field
         $valid = true;
         $this->errors = [];
         foreach ($this->validators as $validator) {
-            if (!$validator->validate($value, $context)) {
+            if (!$validator->validate($filtered, $context)) {
                 $valid = false;
                 if ($error = $validator->getError()) {
                     $this->errors[] = $error;

--- a/src/Gate.php
+++ b/src/Gate.php
@@ -210,7 +210,7 @@ class Gate
 
         $result  = [];
         foreach ($fields as $k => $field) {
-            $filtered = $field->filter($this->rawData[$k] ?? null);
+            $filtered = $field->filter($this->rawData[$k] ?? null, $this->rawData);
 
             if ($validate && !$field->validate($this->rawData[$k] ?? null, $this->rawData)) {
                 if ($field->isRequired()) {

--- a/src/Gate.php
+++ b/src/Gate.php
@@ -218,11 +218,7 @@ class Gate
                     if (count($errors) > 0) {
                         throw new InvalidValue(sprintf('Invalid %s: %s', $k, $errors[0]->message), ...$errors);
                     }
-                    throw new InvalidValue(sprintf(
-                        'The value %s is not valid for %s',
-                        json_encode($this->rawData[$k] ?? null),
-                        $k
-                    ));
+                    throw new InvalidValue(sprintf('The value %s is not valid for %s', json_encode($filtered), $k));
                 } else {
                     $filtered = null;
                 }

--- a/tests/Field/ValidatorTest.php
+++ b/tests/Field/ValidatorTest.php
@@ -156,4 +156,21 @@ class ValidatorTest extends TestCase
         $field->addValidator('notEmpty');
         $field->validate(' body ');
     }
+
+    /** @test */
+    public function executesFilterBeforeValidation()
+    {
+        $field = \Mockery::mock(Field::class)->makePartial();
+        $validator = \Mockery::mock(NotEmpty::class)->makePartial();
+        $field->addValidator($validator);
+
+        $field->shouldReceive('filter')
+            ->with('value', [])
+            ->once()->andReturn(42);
+        $validator->shouldReceive('validate')
+            ->with(42, [])
+            ->once()->andReturn(true);
+
+        $field->validate('value');
+    }
 }

--- a/tests/Gate/GetDataTest.php
+++ b/tests/Gate/GetDataTest.php
@@ -40,7 +40,7 @@ class GetDataTest extends TestCase
         $gate->addField('username', $field);
 
         $field->shouldReceive('filter')->with('john', ['username' => 'john', 'password' => 'abc123'])
-            ->once()->andReturn('john');
+            ->atLeast()->once()->andReturn('john');
 
         $gate->getData();
     }

--- a/tests/Gate/GetDataTest.php
+++ b/tests/Gate/GetDataTest.php
@@ -50,10 +50,10 @@ class GetDataTest extends TestCase
     {
         $gate = new Gate([ 'username' => 'john@example', 'password' => 'abc123' ]);
         $field = \Mockery::mock(Field::class)->makePartial();
-        $field->shouldReceive('filter')->andReturn('john');
         $gate->addField('username', $field);
 
-        $field->shouldReceive('validate')->with('john', ['username' => 'john@example', 'password' => 'abc123'])
+        $field->shouldReceive('validate')
+            ->with('john@example', ['username' => 'john@example', 'password' => 'abc123'])
             ->once()->andReturn(true);
 
         $gate->getData();

--- a/tests/Gate/ValidateTest.php
+++ b/tests/Gate/ValidateTest.php
@@ -59,21 +59,6 @@ class ValidateTest extends TestCase
     }
 
     /** @test */
-    public function usesFilteredValueForValidation()
-    {
-        $field = \Mockery::mock(Field::class)->makePartial();
-        $field->shouldReceive('filter')->with('value', [ 'f' => 'value' ])->once()->andReturn(42);
-        $field->shouldReceive('validate')->with(42, [ 'f' => 'value' ])->once()->andReturn(true);
-
-        $gate = new Gate([ 'f' => 'value' ]);
-        $gate->addField('f', $field);
-
-        $result = $gate->validate();
-
-        self::assertTrue($result);
-    }
-
-    /** @test */
     public function validatesGivenArray()
     {
         $field = \Mockery::mock(Field::class)->makePartial();


### PR DESCRIPTION
This ensures that the value given is filtered before it get's validated.
Beside that `Field::filter()` gets now executed twice what is acceptable
because filters caches (when possible) the filtered value.